### PR TITLE
Revert "Use Criteo custom Cruise Control"

### DIFF
--- a/docker-images/artifacts/kafka-thirdparty-libs/3.7.1/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/3.7.1/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <strimzi-oauth.version>0.15.0</strimzi-oauth.version>
         <jayway-json-path.version>2.9.0</jayway-json-path.version>
-        <cruise-control.version>2.5.137-criteo</cruise-control.version>
+        <cruise-control.version>2.5.137</cruise-control.version>
         <opa-authorizer.version>1.5.1</opa-authorizer.version>
         <kafka-quotas-plugin.version>0.3.1</kafka-quotas-plugin.version>
         <kafka-mirror-maker-2-extensions.version>1.2.0</kafka-mirror-maker-2-extensions.version>
@@ -300,7 +300,7 @@
         </dependency>
         <!-- Cruise Control -->
         <dependency>
-            <groupId>com.criteo.kafka</groupId>
+            <groupId>com.linkedin.cruisecontrol</groupId>
             <artifactId>cruise-control-metrics-reporter</artifactId>
             <version>${cruise-control.version}</version>
             <exclusions>

--- a/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/artifacts/kafka-thirdparty-libs/cc/pom.xml
@@ -16,7 +16,7 @@
     </licenses>
 
     <properties>
-        <cruise-control.version>2.5.137-criteo</cruise-control.version>
+        <cruise-control.version>2.5.137</cruise-control.version>
     </properties>
 
     <repositories>
@@ -28,7 +28,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.criteo.kafka</groupId>
+            <groupId>com.linkedin.cruisecontrol</groupId>
             <artifactId>cruise-control</artifactId>
             <version>${cruise-control.version}</version>
         </dependency>


### PR DESCRIPTION
Reverts Commit 5ea1440: https://github.com/criteo-forks/strimzi-kafka-operator/commit/5ea1440d431486a64e789a2a3ad5627197421752

We want to keep open source code agnostic from Criteo related dependencies.

