### PR TITLE
Add Github Action to build and publish Docker Image to ghcr.io

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -15,10 +15,19 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
+      - name: Determine checkout ref based on event
+        id: set_checkout_ref
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "checkout_ref=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "checkout_ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+          fi 
+
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref:${{ github.event_name == 'pull_request' ? github.event.pull_request.head.ref : github.ref }}
+          ref: ${{ steps.set_checkout_ref.outputs.checkout_ref }}
 
       - name: Set up Java 17
         uses: actions/setup-java@v3

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -69,14 +69,21 @@ jobs:
         id: image_tags
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            # Tag push event: use the git tag as the image tag.
             TAG_NAME=${GITHUB_REF#refs/tags/}
             echo "Detected tag push: $TAG_NAME"
             echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${TAG_NAME}" >> $GITHUB_OUTPUT
-            echo "IMAGE_TAG_STABLE=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:stable" >> $GITHUB_OUTPUT
-          else
-            echo "Detected branch or PR push: ${GITHUB_REF}"
-            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:latest" >> $GITHUB_OUTPUT
             echo "IMAGE_TAG_STABLE=" >> $GITHUB_OUTPUT
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            # Pull Request event: tag with the commit SHA.
+            echo "Detected pull_request event"
+            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAG_STABLE=" >> $GITHUB_OUTPUT
+          else
+            # Branch push event on criteo-0.42.x: tag with commit SHA and update 'latest'.
+            echo "Detected branch push: ${GITHUB_REF}"
+            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAG_STABLE=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:latest" >> $GITHUB_OUTPUT
           fi
           
       - name: Build and Push Docker Image

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -18,8 +18,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref:
-            ${{ github.event_name == 'pull_request' ? github.event.pull_request.head.ref : github.ref }}
+          ref:${{ github.event_name == 'pull_request' ? github.event.pull_request.head.ref : github.ref }}
 
       - name: Set up Java 17
         uses: actions/setup-java@v3

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,0 +1,81 @@
+name: Build and Push Strimzi Docker Image to ghcr.io
+
+on:
+  push:
+    branches:
+      - criteo-0.42.x
+    tags:
+      - 'criteo-0.42.*'
+  pull_request:
+    branches:
+      - criteo-0.42.x
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref:
+            ${{ github.event_name == 'pull_request' ? github.event.pull_request.head.ref : github.ref }}
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build with Maven
+        run: mvn -B -V -e -Dfindbugs.skip -Dcheckstyle.skip -Dpmd.skip=true -Denforcer.skip -Dmaven.javadoc.skip -DskipTests -Dmaven.test.skip.exec -Dlicense.skip=true -Drat.skip=true clean install
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2
+        with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download dependencies
+        working-directory: docker-images/artifacts
+        run: make java_install
+
+      - name: Build Docker Images
+        working-directory: docker-images
+        run: make docker_build
+
+      - name: Determine Image Tags
+        id: image_tags
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG_NAME=${GITHUB_REF#refs/tags/}
+            echo "Detected tag push: $TAG_NAME"
+            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${TAG_NAME}" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAG_STABLE=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:stable" >> $GITHUB_OUTPUT
+          else
+            echo "Detected branch or PR push: ${GITHUB_REF}"
+            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:latest" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAG_STABLE=" >> $GITHUB_OUTPUT
+          fi
+          
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.image_tags.outputs.IMAGE_TAG }}
+            ${{ steps.image_tags.outputs.IMAGE_TAG_STABLE }}

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v3
         with:
-          context: .
+          context: ./docker-images
           push: true
           tags: |
             ${{ steps.image_tags.outputs.IMAGE_TAG }}

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -1,5 +1,8 @@
-name: Build and Push Strimzi Docker Image to ghcr.io
+name: CD Workflow - Build and Release Docker Images
 
+# CD is auto-triggered on push events to the criteo-0.42.x branch (PR merged or git tag)
+# CD can be manually triggered with a specific commit SHA (please publish alternative)
+# See step "Determine Image Tags" for how the image tag is determined based on the event
 on:
   push:
     branches:
@@ -9,20 +12,30 @@ on:
   pull_request:
     branches:
       - criteo-0.42.x
-    types: [opened, synchronize, reopened, closed]
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Commit SHA to build'
+        required: true
 
 jobs:
-  build-and-push:
+  build-and-release:
+    # For pull_request events, only run if the PR is merged.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
+
     steps:
       - name: Determine checkout ref based on event
         id: set_checkout_ref
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "checkout_ref=${{ github.event.inputs.commit_sha }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "checkout_ref=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
           else
             echo "checkout_ref=${{ github.ref }}" >> $GITHUB_OUTPUT
-          fi 
+          fi
 
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -57,7 +70,7 @@ jobs:
             username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download dependencies
+      - name: Maven Build and Install JAR files
         working-directory: docker-images/artifacts
         run: make java_install
 
@@ -65,22 +78,33 @@ jobs:
         working-directory: docker-images
         run: make docker_build
 
+      # Based on triggering event, determine the image tag to use
+      # - For PR merge: use the commit SHA + 'latest'
+      # - For git tag push: use the tag name + 'stable'
+      # - For branch push: use the commit SHA + 'latest'
+      # - For manual trigger: use the provided commit SHA
       - name: Determine Image Tags
         id: image_tags
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            # Tag push event: use the git tag as the image tag.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ -z "${{ github.event.inputs.commit_sha }}" ]; then
+              echo "Error: commit_sha input is required" >&2
+              exit 1
+            fi
+            COMMIT=${{ github.event.inputs.commit_sha }}
+            echo "Detected manual trigger with commit: $COMMIT"
+            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:$COMMIT" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAG_STABLE=" >> $GITHUB_OUTPUT
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG_NAME=${GITHUB_REF#refs/tags/}
             echo "Detected tag push: $TAG_NAME"
-            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${TAG_NAME}" >> $GITHUB_OUTPUT
-            echo "IMAGE_TAG_STABLE=" >> $GITHUB_OUTPUT
-          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            # Pull Request event: tag with the commit SHA.
-            echo "Detected pull_request event"
+            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:$TAG_NAME" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAG_STABLE=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:stable" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "Detected pull_request merged event"
             echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${GITHUB_SHA}" >> $GITHUB_OUTPUT
-            echo "IMAGE_TAG_STABLE=" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAG_STABLE=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:latest" >> $GITHUB_OUTPUT
           else
-            # Branch push event on criteo-0.42.x: tag with commit SHA and update 'latest'.
             echo "Detected branch push: ${GITHUB_REF}"
             echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${GITHUB_SHA}" >> $GITHUB_OUTPUT
             echo "IMAGE_TAG_STABLE=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:latest" >> $GITHUB_OUTPUT

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -25,6 +25,11 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
 
+    env:
+      PROJECT_NAME: strimzi-kafka-operator
+      DOCKER_REGISTRY: ghcr.io
+      DOCKER_ORG: ${{ github.repository_owner }}
+
     steps:
       - name: Determine checkout ref based on event
         id: set_checkout_ref
@@ -83,6 +88,10 @@ jobs:
       # - For git tag push: use the tag name + 'stable'
       # - For branch push: use the commit SHA + 'latest'
       # - For manual trigger: use the provided commit SHA
+      # Determine image tag values to be used by the Makefile.
+      # We output two variables:
+      # - BUILD_TAG: For branch push or PR merge, it's the commit SHA; for tag push, it's the git tag; for manual trigger, it's the provided commit SHA.
+      # - DOCKER_TAG: For branch push and PR merge, we use "latest"; for tag push, we use "stable"; for manual trigger, leave it empty.
       - name: Determine Image Tags
         id: image_tags
         run: |
@@ -93,28 +102,25 @@ jobs:
             fi
             COMMIT=${{ github.event.inputs.commit_sha }}
             echo "Detected manual trigger with commit: $COMMIT"
-            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:$COMMIT" >> $GITHUB_OUTPUT
-            echo "IMAGE_TAG_STABLE=" >> $GITHUB_OUTPUT
+            echo "BUILD_TAG=$COMMIT" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=" >> $GITHUB_OUTPUT
           elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG_NAME=${GITHUB_REF#refs/tags/}
             echo "Detected tag push: $TAG_NAME"
-            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:$TAG_NAME" >> $GITHUB_OUTPUT
-            echo "IMAGE_TAG_STABLE=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:stable" >> $GITHUB_OUTPUT
+            echo "BUILD_TAG=$TAG_NAME" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=stable" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "Detected pull_request merged event"
-            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${GITHUB_SHA}" >> $GITHUB_OUTPUT
-            echo "IMAGE_TAG_STABLE=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:latest" >> $GITHUB_OUTPUT
+            echo "BUILD_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=latest" >> $GITHUB_OUTPUT
           else
             echo "Detected branch push: ${GITHUB_REF}"
-            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${GITHUB_SHA}" >> $GITHUB_OUTPUT
-            echo "IMAGE_TAG_STABLE=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:latest" >> $GITHUB_OUTPUT
+            echo "BUILD_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=latest" >> $GITHUB_OUTPUT
           fi
           
-      - name: Build and Push Docker Image
-        uses: docker/build-push-action@v3
-        with:
-          context: ./docker-images
-          push: true
-          tags: |
-            ${{ steps.image_tags.outputs.IMAGE_TAG }}
-            ${{ steps.image_tags.outputs.IMAGE_TAG_STABLE }}
+      - name: Tag Docker Image using Makefile
+        run: make docker_tag DOCKER_TAG=${{ steps.image_tags.outputs.DOCKER_TAG }} BUILD_TAG=${{ steps.image_tags.outputs.BUILD_TAG }}
+
+      - name: Push Docker Image using Makefile
+        run: make docker_push DOCKER_TAG=${{ steps.image_tags.outputs.DOCKER_TAG }} BUILD_TAG=${{ steps.image_tags.outputs.BUILD_TAG }}

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -95,6 +95,7 @@ jobs:
       - name: Determine Image Tags
         id: image_tags
         run: |
+          echo "BUILD_TAG=latest" >> $GITHUB_OUTPUT
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ -z "${{ github.event.inputs.commit_sha }}" ]; then
               echo "Error: commit_sha input is required" >&2
@@ -102,25 +103,33 @@ jobs:
             fi
             COMMIT=${{ github.event.inputs.commit_sha }}
             echo "Detected manual trigger with commit: $COMMIT"
-            echo "BUILD_TAG=$COMMIT" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG_SHA=$COMMIT" >> $GITHUB_OUTPUT
             echo "DOCKER_TAG=" >> $GITHUB_OUTPUT
           elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG_NAME=${GITHUB_REF#refs/tags/}
             echo "Detected tag push: $TAG_NAME"
-            echo "BUILD_TAG=$TAG_NAME" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG_SHA=$TAG_NAME" >> $GITHUB_OUTPUT
             echo "DOCKER_TAG=stable" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "Detected pull_request merged event"
-            echo "BUILD_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG_SHA=${GITHUB_SHA}" >> $GITHUB_OUTPUT
             echo "DOCKER_TAG=latest" >> $GITHUB_OUTPUT
           else
             echo "Detected branch push: ${GITHUB_REF}"
-            echo "BUILD_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG_SHA=${GITHUB_SHA}" >> $GITHUB_OUTPUT
             echo "DOCKER_TAG=latest" >> $GITHUB_OUTPUT
           fi
-          
-      - name: Tag Docker Image using Makefile
+
+      - name: Tag Docker Image using Makefile (SHA Tag)
+        run: make docker_tag DOCKER_TAG=${{ steps.image_tags.outputs.DOCKER_TAG_SHA }} BUILD_TAG=${{ steps.image_tags.outputs.BUILD_TAG }}
+
+      - name: Tag Docker Image using Makefile (Extra Tag - latest/stable)
+        if: ${{ steps.image_tags.outputs.DOCKER_TAG != '' }}
         run: make docker_tag DOCKER_TAG=${{ steps.image_tags.outputs.DOCKER_TAG }} BUILD_TAG=${{ steps.image_tags.outputs.BUILD_TAG }}
 
-      - name: Push Docker Image using Makefile
+      - name: Push Docker Image using Makefile (SHA Tag)
+        run: make docker_push DOCKER_TAG=${{ steps.image_tags.outputs.DOCKER_TAG_SHA }} BUILD_TAG=${{ steps.image_tags.outputs.BUILD_TAG }}
+
+      - name: Push Docker Image using Makefile (Extra Tag = latest/stable)
+        if: ${{ steps.image_tags.outputs.DOCKER_TAG != '' }}
         run: make docker_push DOCKER_TAG=${{ steps.image_tags.outputs.DOCKER_TAG }} BUILD_TAG=${{ steps.image_tags.outputs.BUILD_TAG }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -61,15 +61,15 @@ jobs:
             # For tag push events, use the git tag as the image tag.
             TAG_NAME=${GITHUB_REF#refs/tags/}
             echo "Detected tag push: $TAG_NAME"
-            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${TAG_NAME}" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAG=${TAG_NAME}" >> $GITHUB_OUTPUT
           elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             # For pull requests, use the commit SHA.
             echo "Detected pull_request event"
-            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
           else
             # For branch pushes, use the commit SHA.
             echo "Detected branch push: ${GITHUB_REF}"
-            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
           fi
 
       - name: Tag Docker Image using Makefile

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -66,12 +66,12 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG_NAME=${GITHUB_REF#refs/tags/}
             echo "Detected tag push: $TAG_NAME"
-            echo "BUILD_TAG=$TAG_NAME" >> $GITHUB_OUTPUT
-            echo "DOCKER_TAG=stable" >> $GITHUB_OUTPUT
+            echo "BUILD_TAG=latest" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=$TAG_NAME" >> $GITHUB_OUTPUT
           else
             echo "Detected branch push: ${GITHUB_REF}"
-            echo "BUILD_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
-            echo "DOCKER_TAG=latest" >> $GITHUB_OUTPUT
+            echo "BUILD_TAG=latest" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
           fi
 
       - name: List Docker Images

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -75,6 +75,6 @@ jobs:
       - name: Build Docker Image (CI Only)
         uses: docker/build-push-action@v3
         with:
-          context: .
+          context: ./docker-images
           push: false
           tags: ${{ steps.image_tags.outputs.IMAGE_TAG }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -10,6 +10,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    env:
+      PROJECT_NAME: strimzi-kafka-operator
+      DOCKER_REGISTRY: ghcr.io
+      DOCKER_ORG: ${{ github.repository_owner }}
+      
     steps:
       - name: Determine checkout ref based on event
         id: set_checkout_ref

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -54,27 +54,39 @@ jobs:
         working-directory: docker-images
         run: make docker_build
 
-      - name: Determine Image Tag
+      - name: Determine Image Tags
         id: image_tags
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            # For tag push events, use the git tag as the image tag.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ -z "${{ github.event.inputs.commit_sha }}" ]; then
+              echo "Error: commit_sha input is required" >&2
+              exit 1
+            fi
+            COMMIT=${{ github.event.inputs.commit_sha }}
+            echo "Detected manual trigger with commit: $COMMIT"
+            echo "BUILD_TAG=$COMMIT" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=" >> $GITHUB_OUTPUT
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG_NAME=${GITHUB_REF#refs/tags/}
             echo "Detected tag push: $TAG_NAME"
-            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${TAG_NAME}" >> $GITHUB_OUTPUT
-          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            # For pull requests, use the commit SHA.
-            echo "Detected pull_request event"
-            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "BUILD_TAG=$TAG_NAME" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=stable" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "Detected pull_request merged event"
+            echo "BUILD_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=latest" >> $GITHUB_OUTPUT
           else
-            # For branch pushes, use the commit SHA.
             echo "Detected branch push: ${GITHUB_REF}"
-            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "BUILD_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=latest" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build Docker Image (CI Only)
-        uses: docker/build-push-action@v3
-        with:
-          context: ./docker-images
-          push: false
-          tags: ${{ steps.image_tags.outputs.IMAGE_TAG }}
+      - name: Tag Docker Image using Makefile
+        working-directory: docker-images
+        run: make docker_tag BUILD_TAG=${{ steps.image_tags.outputs.IMAGE_TAG }}
+        
+      - name: Print Success Message with Image Tags
+        run: |
+          echo "Success: Docker image build complete."
+          echo "BUILD_TAG: ${{ steps.image_tags.outputs.BUILD_TAG }}"
+          echo "DOCKER_TAG: ${{ steps.image_tags.outputs.DOCKER_TAG }}"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -63,14 +63,13 @@ jobs:
       - name: Determine Image Tags
         id: image_tags
         run: |
+          echo "BUILD_TAG=latest" >> $GITHUB_OUTPUT
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG_NAME=${GITHUB_REF#refs/tags/}
             echo "Detected tag push: $TAG_NAME"
-            echo "BUILD_TAG=latest" >> $GITHUB_OUTPUT
             echo "DOCKER_TAG=$TAG_NAME" >> $GITHUB_OUTPUT
           else
             echo "Detected branch push: ${GITHUB_REF}"
-            echo "BUILD_TAG=latest" >> $GITHUB_OUTPUT
             echo "DOCKER_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,0 +1,83 @@
+name: CI Workflow - Build Docker Images
+
+# CI is applied to every push and pull request,
+# except for the upstream branch that is auto-tracking the original Strimzi repository.
+on:
+  push:
+    branches-ignore:
+      - upstream
+  pull_request:
+    branches-ignore:
+      - upstream
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine checkout ref based on event
+        id: set_checkout_ref
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "checkout_ref=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "checkout_ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+          fi 
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.set_checkout_ref.outputs.checkout_ref }}
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build with Maven
+        run: mvn -B -V -e -Dfindbugs.skip -Dcheckstyle.skip -Dpmd.skip=true -Denforcer.skip -Dmaven.javadoc.skip -DskipTests -Dmaven.test.skip.exec -Dlicense.skip=true -Drat.skip=true clean install
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Maven Build and Install JAR files
+        working-directory: docker-images/artifacts
+        run: make java_install
+
+      - name: Build Docker Images
+        working-directory: docker-images
+        run: make docker_build
+
+      - name: Determine Image Tag
+        id: image_tags
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            # For tag push events, use the git tag as the image tag.
+            TAG_NAME=${GITHUB_REF#refs/tags/}
+            echo "Detected tag push: $TAG_NAME"
+            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${TAG_NAME}" >> $GITHUB_OUTPUT
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            # For pull requests, use the commit SHA.
+            echo "Detected pull_request event"
+            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${GITHUB_SHA}" >> $GITHUB_OUTPUT
+          else
+            # For branch pushes, use the commit SHA.
+            echo "Detected branch push: ${GITHUB_REF}"
+            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${GITHUB_SHA}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build Docker Image (CI Only)
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.image_tags.outputs.IMAGE_TAG }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -60,31 +60,28 @@ jobs:
         working-directory: docker-images
         run: make docker_build
 
-      - name: Determine Image Tag
+      - name: Determine Image Tags
         id: image_tags
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            # For tag push events, use the git tag as the image tag.
             TAG_NAME=${GITHUB_REF#refs/tags/}
             echo "Detected tag push: $TAG_NAME"
-            echo "IMAGE_TAG=${TAG_NAME}" >> $GITHUB_OUTPUT
-          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            # For pull requests, use the commit SHA.
-            echo "Detected pull_request event"
-            echo "IMAGE_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "BUILD_TAG=$TAG_NAME" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=stable" >> $GITHUB_OUTPUT
           else
-            # For branch pushes, use the commit SHA.
             echo "Detected branch push: ${GITHUB_REF}"
-            echo "IMAGE_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "BUILD_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=latest" >> $GITHUB_OUTPUT
           fi
+
       - name: List Docker Images
         run: docker images
 
       - name: Tag Docker Image using Makefile
-        working-directory: docker-images
-        run: make docker_tag BUILD_TAG=${{ steps.image_tags.outputs.IMAGE_TAG }}
-        
+        run: make docker_tag DOCKER_TAG=${{ steps.image_tags.outputs.DOCKER_TAG }} BUILD_TAG=${{ steps.image_tags.outputs.BUILD_TAG }}
+
       - name: Print Success Message with Image Tags
         run: |
           echo "Success: Docker image build complete."
-          echo "IMAGE_TAG: ${{ steps.image_tags.outputs.IMAGE_TAG }}"
+          echo "DOCKER_TAG: ${{ steps.image_tags.outputs.DOCKER_TAG }}"
+          echo "BUILD_TAG: ${{ steps.image_tags.outputs.BUILD_TAG }}"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -54,31 +54,22 @@ jobs:
         working-directory: docker-images
         run: make docker_build
 
-      - name: Determine Image Tags
+      - name: Determine Image Tag
         id: image_tags
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [ -z "${{ github.event.inputs.commit_sha }}" ]; then
-              echo "Error: commit_sha input is required" >&2
-              exit 1
-            fi
-            COMMIT=${{ github.event.inputs.commit_sha }}
-            echo "Detected manual trigger with commit: $COMMIT"
-            echo "BUILD_TAG=$COMMIT" >> $GITHUB_OUTPUT
-            echo "DOCKER_TAG=" >> $GITHUB_OUTPUT
-          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            # For tag push events, use the git tag as the image tag.
             TAG_NAME=${GITHUB_REF#refs/tags/}
             echo "Detected tag push: $TAG_NAME"
-            echo "BUILD_TAG=$TAG_NAME" >> $GITHUB_OUTPUT
-            echo "DOCKER_TAG=stable" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "Detected pull_request merged event"
-            echo "BUILD_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
-            echo "DOCKER_TAG=latest" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${TAG_NAME}" >> $GITHUB_OUTPUT
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            # For pull requests, use the commit SHA.
+            echo "Detected pull_request event"
+            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${GITHUB_SHA}" >> $GITHUB_OUTPUT
           else
+            # For branch pushes, use the commit SHA.
             echo "Detected branch push: ${GITHUB_REF}"
-            echo "BUILD_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
-            echo "DOCKER_TAG=latest" >> $GITHUB_OUTPUT
+            echo "IMAGE_TAG=ghcr.io/${GITHUB_REPOSITORY_OWNER}/strimzi-kafka-operator:${GITHUB_SHA}" >> $GITHUB_OUTPUT
           fi
 
       - name: Tag Docker Image using Makefile
@@ -88,5 +79,4 @@ jobs:
       - name: Print Success Message with Image Tags
         run: |
           echo "Success: Docker image build complete."
-          echo "BUILD_TAG: ${{ steps.image_tags.outputs.BUILD_TAG }}"
-          echo "DOCKER_TAG: ${{ steps.image_tags.outputs.DOCKER_TAG }}"
+          echo "IMAGE_TAG: ${{ steps.image_tags.outputs.IMAGE_TAG }}"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -77,6 +77,8 @@ jobs:
             echo "Detected branch push: ${GITHUB_REF}"
             echo "IMAGE_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
           fi
+      - name: List Docker Images
+        run: docker images
 
       - name: Tag Docker Image using Makefile
         working-directory: docker-images

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,12 +1,9 @@
 name: CI Workflow - Build Docker Images
 
-# CI is applied to every push and pull request,
+# CI is applied to every push event to any branch,
 # except for the upstream branch that is auto-tracking the original Strimzi repository.
 on:
   push:
-    branches-ignore:
-      - upstream
-  pull_request:
     branches-ignore:
       - upstream
 


### PR DESCRIPTION
GA workflow that builds Strimzi image and publish it to ghcr.io/criteo-fork/strimzi-kafka-operator with tag based on trigger:
- merge to criteo-0.42.x -> latest tag
- git tag release 0.42.* -> stable tag + "0.42.*" tag
- opened or updated pull request -> dev tag with pull request ID