### PR TITLE
Upgrade to criteo-0.45.x: Use Kafka 3.9.1 only and build images in CI/CD

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -1,0 +1,135 @@
+name: CD Workflow - Build and Release Docker Images
+
+# CD is auto-triggered on push events to the criteo-0.45.x branch (PR merged or git tag)
+# CD can be manually triggered with a specific commit SHA (please publish alternative)
+# See step "Determine Image Tags" for how the image tag is determined based on the event
+on:
+  push:
+    branches:
+      - criteo-0.45.x
+    tags:
+      - 'criteo-0.45.*'
+  pull_request:
+    branches:
+      - criteo-0.45.x
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Commit SHA to build'
+        required: true
+
+jobs:
+  build-and-release:
+    # For pull_request events, only run if the PR is merged.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+
+    env:
+      PROJECT_NAME: strimzi-kafka-operator
+      DOCKER_REGISTRY: ghcr.io
+      DOCKER_ORG: ${{ github.repository_owner }}
+
+    steps:
+      - name: Determine checkout ref based on event
+        id: set_checkout_ref
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "checkout_ref=${{ github.event.inputs.commit_sha }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "checkout_ref=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "checkout_ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.set_checkout_ref.outputs.checkout_ref }}
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build with Maven
+        run: mvn -B -V -e -Dfindbugs.skip -Dcheckstyle.skip -Dpmd.skip=true -Denforcer.skip -Dmaven.javadoc.skip -DskipTests -Dmaven.test.skip.exec -Dlicense.skip=true -Drat.skip=true clean install
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2
+        with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Maven Build and Install JAR files
+        working-directory: docker-images/artifacts
+        run: make java_install
+
+      - name: Build Docker Images
+        working-directory: docker-images
+        run: make docker_build
+
+      # Based on triggering event, determine the image tag to use
+      # - For PR merge: use the commit SHA + 'latest'
+      # - For git tag push: use the tag name + 'stable'
+      # - For branch push: use the commit SHA + 'latest'
+      # - For manual trigger: use the provided commit SHA
+      # Determine image tag values to be used by the Makefile.
+      # We output two variables:
+      # - BUILD_TAG: For branch push or PR merge, it's the commit SHA; for tag push, it's the git tag; for manual trigger, it's the provided commit SHA.
+      # - DOCKER_TAG: For branch push and PR merge, we use "latest"; for tag push, we use "stable"; for manual trigger, leave it empty.
+      - name: Determine Image Tags
+        id: image_tags
+        run: |
+          echo "BUILD_TAG=latest" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            if [ -z "${{ github.event.inputs.commit_sha }}" ]; then
+              echo "Error: commit_sha input is required" >&2
+              exit 1
+            fi
+            COMMIT=${{ github.event.inputs.commit_sha }}
+            echo "Detected manual trigger with commit: $COMMIT"
+            echo "DOCKER_TAG_SHA=$COMMIT" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=" >> $GITHUB_OUTPUT
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG_NAME=${GITHUB_REF#refs/tags/}
+            echo "Detected tag push: $TAG_NAME"
+            echo "DOCKER_TAG_SHA=$TAG_NAME" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=stable" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "Detected pull_request merged event"
+            echo "DOCKER_TAG_SHA=${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=latest" >> $GITHUB_OUTPUT
+          else
+            echo "Detected branch push: ${GITHUB_REF}"
+            echo "DOCKER_TAG_SHA=${GITHUB_SHA}" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Tag Docker Image using Makefile (SHA Tag)
+        run: make docker_tag DOCKER_TAG=${{ steps.image_tags.outputs.DOCKER_TAG_SHA }} BUILD_TAG=${{ steps.image_tags.outputs.BUILD_TAG }}
+
+      - name: Tag Docker Image using Makefile (Extra Tag - latest/stable)
+        if: ${{ steps.image_tags.outputs.DOCKER_TAG != '' }}
+        run: make docker_tag DOCKER_TAG=${{ steps.image_tags.outputs.DOCKER_TAG }} BUILD_TAG=${{ steps.image_tags.outputs.BUILD_TAG }}
+
+      - name: Push Docker Image using Makefile (SHA Tag)
+        run: make docker_push DOCKER_TAG=${{ steps.image_tags.outputs.DOCKER_TAG_SHA }} BUILD_TAG=${{ steps.image_tags.outputs.BUILD_TAG }}
+
+      - name: Push Docker Image using Makefile (Extra Tag = latest/stable)
+        if: ${{ steps.image_tags.outputs.DOCKER_TAG != '' }}
+        run: make docker_push DOCKER_TAG=${{ steps.image_tags.outputs.DOCKER_TAG }} BUILD_TAG=${{ steps.image_tags.outputs.BUILD_TAG }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,0 +1,86 @@
+name: CI Workflow - Build Docker Images
+
+# CI is applied to every push event to any branch,
+# except for the upstream branch that is auto-tracking the original Strimzi repository.
+on:
+  push:
+    branches-ignore:
+      - upstream
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      PROJECT_NAME: strimzi-kafka-operator
+      DOCKER_REGISTRY: ghcr.io
+      DOCKER_ORG: ${{ github.repository_owner }}
+      
+    steps:
+      - name: Determine checkout ref based on event
+        id: set_checkout_ref
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "checkout_ref=${{ github.event.pull_request.head.ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "checkout_ref=${{ github.ref }}" >> $GITHUB_OUTPUT
+          fi 
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.set_checkout_ref.outputs.checkout_ref }}
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: maven
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Build with Maven
+        run: mvn -B -V -e -Dfindbugs.skip -Dcheckstyle.skip -Dpmd.skip=true -Denforcer.skip -Dmaven.javadoc.skip -DskipTests -Dmaven.test.skip.exec -Dlicense.skip=true -Drat.skip=true clean install
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Maven Build and Install JAR files
+        working-directory: docker-images/artifacts
+        run: make java_install
+
+      - name: Build Docker Images
+        working-directory: docker-images
+        run: make docker_build
+
+      - name: Determine Image Tags
+        id: image_tags
+        run: |
+          echo "BUILD_TAG=latest" >> $GITHUB_OUTPUT
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG_NAME=${GITHUB_REF#refs/tags/}
+            echo "Detected tag push: $TAG_NAME"
+            echo "DOCKER_TAG=$TAG_NAME" >> $GITHUB_OUTPUT
+          else
+            echo "Detected branch push: ${GITHUB_REF}"
+            echo "DOCKER_TAG=${GITHUB_SHA}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: List Docker Images
+        run: docker images
+
+      - name: Tag Docker Image using Makefile
+        run: make docker_tag DOCKER_TAG=${{ steps.image_tags.outputs.DOCKER_TAG }} BUILD_TAG=${{ steps.image_tags.outputs.BUILD_TAG }}
+
+      - name: Print Success Message with Image Tags
+        run: |
+          echo "Success: Docker image build complete."
+          echo "DOCKER_TAG: ${{ steps.image_tags.outputs.DOCKER_TAG }}"
+          echo "BUILD_TAG: ${{ steps.image_tags.outputs.BUILD_TAG }}"

--- a/.github/workflows/upstream-fork-sync.yml
+++ b/.github/workflows/upstream-fork-sync.yml
@@ -1,0 +1,36 @@
+# This workflow keeps out `upstream` branch always in-sync with upstream `main` branch
+# Fetches changes every morning, and only apply them if possible Fast-Forward.
+on:
+  schedule:
+    - cron:  '0 8 * * 1-5'
+  workflow_dispatch:
+
+jobs:
+  sync_with_upstream:
+    runs-on: ubuntu-latest
+    name: Sync upstream branch with upstream/main:latest
+
+    steps:
+    - name: Checkout our upstream branch
+      uses: actions/checkout@v2
+      with:
+        ref: upstream
+
+    - name: Pull (Fast-Forward) upstream changes
+      id: sync
+      uses: aormsby/Fork-Sync-With-Upstream-action@v2.1
+      with:
+        upstream_repository: strimzi/strimzi-kafka-operator
+        upstream_branch: main
+        target_branch: upstream
+        git_getch_args: --tags     # we want to fetch tags
+        git_pull_args: --ff-only   # always Fast-Forward, should always pass
+        
+    # Display a message if 'sync' step had new commits
+    - name: Check for new commits
+      if: steps.sync.outputs.has_new_commits
+      run: echo "There were new commits."
+
+    # Print a helpful timestamp for later auditing
+    - name: Timestamp
+      run: date

--- a/documentation/modules/snip-kafka-versions.adoc
+++ b/documentation/modules/snip-kafka-versions.adoc
@@ -6,8 +6,5 @@
 [options="header"]
 |=================
 |Kafka version |Inter-broker protocol version |Log message format version| ZooKeeper version
-| 3.8.0 | 3.8 | 3.8 | 3.8.4
-| 3.8.1 | 3.8 | 3.8 | 3.8.4
-| 3.9.0 | 3.9 | 3.9 | 3.8.4
 | 3.9.1 | 3.9 | 3.9 | 3.8.4
 |=================

--- a/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
+++ b/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
@@ -10,27 +10,15 @@
             - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
               value: {{ template "strimzi.image" (merge . (dict "key" "cruiseControl" "tagSuffix" "-kafka-3.9.1")) }}
             - name: STRIMZI_KAFKA_IMAGES
-              value: |                 
-                3.8.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.8.0")) }}
-                3.8.1={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.8.1")) }}
-                3.9.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.9.0")) }}
+              value: |
                 3.9.1={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.9.1")) }}
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
-              value: |                 
-                3.8.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.8.0")) }}
-                3.8.1={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.8.1")) }}
-                3.9.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.9.0")) }}
+              value: |
                 3.9.1={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.9.1")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
-              value: |                 
-                3.8.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.8.0")) }}
-                3.8.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.8.1")) }}
-                3.9.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.9.0")) }}
+              value: |
                 3.9.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.9.1")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
-              value: |                 
-                3.8.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.8.0")) }}
-                3.8.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.8.1")) }}
-                3.9.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.9.0")) }}
+              value: |
                 3.9.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.9.1")) }}
 {{- end -}}

--- a/kafka-versions.yaml
+++ b/kafka-versions.yaml
@@ -343,7 +343,7 @@
   checksum: 0A33B7BE7B6FA53249BA80F9D02CDA71ED81927C160AA6EE9BE1E3D3C1C4B50466FFC905293143FD88CEAC7F5E7D8F5BEC28EF972ADDD3C459CC8B1291E738AA
   zookeeper: 3.8.4
   third-party-libs: 3.8.x
-  supported: true
+  supported: false
   default: false
 - version: 3.8.1
   format: 3.8
@@ -353,7 +353,7 @@
   checksum: B43FADA353B7DCA51C0F90ACF594EC1CE06B2344C046D4059D4DEAB0615E0E3E76E92ECCDBDFA1ADAD1FBDE76C5F25E71ACD0DB013FB4B1778827448B5285EDF
   zookeeper: 3.8.4
   third-party-libs: 3.8.x
-  supported: true
+  supported: false
   default: false
 - version: 3.9.0
   format: 3.9
@@ -363,7 +363,7 @@
   checksum: 5324C1F44D4C84EA469712C2CC3D2D15545C3716EDBB5353722DF9C661FCC78B031FCF07D1C4F0309C5FDB32686665DFB0CFFE55210CD3A1FE2A370538CB4E6D
   zookeeper: 3.8.4
   third-party-libs: 3.9.x
-  supported: true
+  supported: false
   default: false
 - version: 3.9.1
   format: 3.9

--- a/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
+++ b/packaging/helm-charts/helm3/strimzi-kafka-operator/templates/_kafka_image_map.tpl
@@ -10,27 +10,15 @@
             - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
               value: {{ template "strimzi.image" (merge . (dict "key" "cruiseControl" "tagSuffix" "-kafka-3.9.1")) }}
             - name: STRIMZI_KAFKA_IMAGES
-              value: |                 
-                3.8.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.8.0")) }}
-                3.8.1={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.8.1")) }}
-                3.9.0={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.9.0")) }}
+              value: |
                 3.9.1={{ template "strimzi.image" (merge . (dict "key" "kafka" "tagSuffix" "-kafka-3.9.1")) }}
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
-              value: |                 
-                3.8.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.8.0")) }}
-                3.8.1={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.8.1")) }}
-                3.9.0={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.9.0")) }}
+              value: |
                 3.9.1={{ template "strimzi.image" (merge . (dict "key" "kafkaConnect" "tagSuffix" "-kafka-3.9.1")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
-              value: |                 
-                3.8.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.8.0")) }}
-                3.8.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.8.1")) }}
-                3.9.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.9.0")) }}
+              value: |
                 3.9.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker" "tagSuffix" "-kafka-3.9.1")) }}
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
-              value: |                 
-                3.8.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.8.0")) }}
-                3.8.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.8.1")) }}
-                3.9.0={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.9.0")) }}
+              value: |
                 3.9.1={{ template "strimzi.image" (merge . (dict "key" "kafkaMirrorMaker2" "tagSuffix" "-kafka-3.9.1")) }}
 {{- end -}}


### PR DESCRIPTION
 ## Summary
  - Add GitHub Actions workflows (CI, CD, upstream sync) targeting `criteo-0.45.x`
  - Restrict supported Kafka versions to **3.9.1 only** (disable 3.8.0, 3.8.1, 3.9.0)
  - Base: Strimzi **0.45.1** (last version with ZooKeeper support, includes Kafka 3.9.1, KRaft migration bugfix, CVE-2024-57699 fix)

  ## Changed files
  - `.github/workflows/` - CI/CD and upstream sync workflows
  - `kafka-versions.yaml` - mark 3.8.x and 3.9.0 as unsupported
  - `documentation/modules/snip-kafka-versions.adoc` - doc snippet
  - `helm-charts/` and `packaging/helm-charts/` - image maps restricted to 3.9.1