### PR TITLE
Fix CI: pin GAs to allowed SHA references

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -43,19 +43,19 @@ jobs:
           fi
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ steps.set_checkout_ref.outputs.checkout_ref }}
 
       - name: Set up Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: maven
 
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -66,10 +66,10 @@ jobs:
         run: mvn -B -V -e -Dfindbugs.skip -Dcheckstyle.skip -Dpmd.skip=true -Denforcer.skip -Dmaven.javadoc.skip -DskipTests -Dmaven.test.skip.exec -Dlicense.skip=true -Drat.skip=true clean install
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v2
 
       - name: Login to Github Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v2
         with:
             registry: ghcr.io
             username: ${{ github.actor }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -27,19 +27,19 @@ jobs:
           fi 
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ steps.set_checkout_ref.outputs.checkout_ref }}
 
       - name: Set up Java 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: maven
 
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@0c907a75c2c80ebcb7f088228285e798b750cf8f # v4.2.1
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -50,7 +50,7 @@ jobs:
         run: mvn -B -V -e -Dfindbugs.skip -Dcheckstyle.skip -Dpmd.skip=true -Denforcer.skip -Dmaven.javadoc.skip -DskipTests -Dmaven.test.skip.exec -Dlicense.skip=true -Drat.skip=true clean install
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v2
 
       - name: Maven Build and Install JAR files
         working-directory: docker-images/artifacts

--- a/.github/workflows/upstream-fork-sync.yml
+++ b/.github/workflows/upstream-fork-sync.yml
@@ -1,5 +1,5 @@
-# This workflow keeps out `upstream` branch always in-sync with upstream `main` branch
-# Fetches changes every morning, and only apply them if possible Fast-Forward.
+# This workflow keeps our `upstream` branch always in-sync with upstream `main` branch
+# Fetches changes every morning, and only applies them if possible Fast-Forward.
 on:
   schedule:
     - cron:  '0 8 * * 1-5'
@@ -12,25 +12,17 @@ jobs:
 
     steps:
     - name: Checkout our upstream branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         ref: upstream
+        fetch-depth: 0
 
     - name: Pull (Fast-Forward) upstream changes
-      id: sync
-      uses: aormsby/Fork-Sync-With-Upstream-action@v2.1
-      with:
-        upstream_repository: strimzi/strimzi-kafka-operator
-        upstream_branch: main
-        target_branch: upstream
-        git_getch_args: --tags     # we want to fetch tags
-        git_pull_args: --ff-only   # always Fast-Forward, should always pass
-        
-    # Display a message if 'sync' step had new commits
-    - name: Check for new commits
-      if: steps.sync.outputs.has_new_commits
-      run: echo "There were new commits."
+      run: |
+        git remote add upstream https://github.com/strimzi/strimzi-kafka-operator.git
+        git fetch upstream main --tags
+        git merge --ff-only upstream/main
+        git push origin upstream --tags
 
-    # Print a helpful timestamp for later auditing
     - name: Timestamp
       run: date


### PR DESCRIPTION
criteo-forks org doesn't allow version tags anymore, we should pin dependencies to SHAs Replace third-party Fork-Sync action with plain git commands

