### PR TITLE
Add Kafka broker ServiceAccount override

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
@@ -49,7 +49,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
     "version", "metadataVersion", "replicas", "image", "listeners", "config", "storage", "authorization", "rack",
-    "brokerRackInitImage", "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "resources", "metricsConfig",
+    "brokerRackInitImage", "serviceAccountName", "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "resources", "metricsConfig",
     "logging", "template", "tieredStorage", "quotas"})
 @EqualsAndHashCode
 @ToString
@@ -78,6 +78,7 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
     private Logging logging;
     private Integer replicas;
     private String image;
+    private String serviceAccountName;
     private ResourceRequirements resources;
     private Probe livenessProbe;
     private Probe readinessProbe;
@@ -188,6 +189,17 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
 
     public void setImage(String image) {
         this.image = image;
+    }
+
+    @Description("The name of the service account used by the Kafka pods. " +
+            "If not set, the default Kafka service account for the cluster will be used.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String getServiceAccountName() {
+        return serviceAccountName;
+    }
+
+    public void setServiceAccountName(String serviceAccountName) {
+        this.serviceAccountName = serviceAccountName;
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/nodepool/KafkaNodePoolSpec.java
@@ -29,7 +29,7 @@ import java.util.List;
         builderPackage = Constants.FABRIC8_KUBERNETES_API
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({"replicas", "storage", "roles", "resources", "jvmOptions", "template"})
+@JsonPropertyOrder({"replicas", "storage", "roles", "resources", "jvmOptions", "serviceAccountName", "template"})
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KafkaNodePoolSpec extends Spec {
@@ -38,6 +38,7 @@ public class KafkaNodePoolSpec extends Spec {
     private List<ProcessRoles> roles;
     private ResourceRequirements resources;
     private JvmOptions jvmOptions;
+    private String serviceAccountName;
     private KafkaNodePoolTemplate template;
 
     @Description("The number of pods in the pool.")
@@ -93,6 +94,17 @@ public class KafkaNodePoolSpec extends Spec {
 
     public void setJvmOptions(JvmOptions jvmOptions) {
         this.jvmOptions = jvmOptions;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Description("The name of the service account used by the pods in this pool. " +
+            "If not set, the Kafka cluster service account is used.")
+    public String getServiceAccountName() {
+        return serviceAccountName;
+    }
+
+    public void setServiceAccountName(String serviceAccountName) {
+        this.serviceAccountName = serviceAccountName;
     }
 
     @Description("Template for pool resources. " +

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -1198,7 +1198,7 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                             namespace,
                             pool.labels.withStrimziBrokerRole(node.broker()).withStrimziControllerRole(node.controller()),
                             pool.componentName,
-                            componentName,
+                            effectiveServiceAccountName(pool),
                             pool.templatePod,
                             DEFAULT_POD_LABELS,
                             podAnnotationsProvider.apply(node),
@@ -1650,11 +1650,15 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      */
     public ClusterRoleBinding generateClusterRoleBinding(String assemblyNamespace) {
         if (rack != null || isExposedWithNodePort()) {
-            Subject subject = new SubjectBuilder()
-                    .withKind("ServiceAccount")
-                    .withName(componentName)
-                    .withNamespace(assemblyNamespace)
-                    .build();
+            List<Subject> subjects = nodePools.stream()
+                    .map(this::effectiveServiceAccountName)
+                    .distinct()
+                    .map(name -> new SubjectBuilder()
+                            .withKind("ServiceAccount")
+                            .withName(name)
+                            .withNamespace(assemblyNamespace)
+                            .build())
+                    .toList();
 
             RoleRef roleRef = new RoleRefBuilder()
                     .withName("strimzi-kafka-broker")
@@ -1663,10 +1667,14 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                     .build();
 
             return RbacUtils
-                    .createClusterRoleBinding(KafkaResources.initContainerClusterRoleBindingName(cluster, namespace), roleRef, List.of(subject), labels, templateInitClusterRoleBinding);
+                    .createClusterRoleBinding(KafkaResources.initContainerClusterRoleBindingName(cluster, namespace), roleRef, subjects, labels, templateInitClusterRoleBinding);
         } else {
             return null;
         }
+    }
+
+    private String effectiveServiceAccountName(KafkaPool pool) {
+        return pool.getServiceAccountName() != null ? pool.getServiceAccountName() : componentName;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaPool.java
@@ -53,6 +53,11 @@ public class KafkaPool extends AbstractModel {
     protected Storage storage;
 
     /**
+     * Service account name used by the pods in this pool.
+     */
+    protected String serviceAccountName;
+
+    /**
      * Process roles the nodes in this pool will take. This field is set in the fromCrd method, here it is only
      * set to null to avoid spotbugs complains. For KRaft based cluster, the nodes in this pool might be brokers,
      * controllers or both. For ZooKeeper based clusters, nodes can be only brokers.
@@ -153,6 +158,7 @@ public class KafkaPool extends AbstractModel {
         result.jvmOptions = pool.getSpec().getJvmOptions() != null ? pool.getSpec().getJvmOptions() : kafka.getSpec().getKafka().getJvmOptions();
         result.resources = pool.getSpec().getResources() != null ? pool.getSpec().getResources() : kafka.getSpec().getKafka().getResources();
         result.processRoles = new HashSet<>(pool.getSpec().getRoles());
+        result.serviceAccountName = pool.getSpec().getServiceAccountName() != null ? pool.getSpec().getServiceAccountName() : kafka.getSpec().getKafka().getServiceAccountName();
 
         if (oldStorage != null) {
             Storage newStorage = pool.getSpec().getStorage();
@@ -341,5 +347,12 @@ public class KafkaPool extends AbstractModel {
      */
     public Set<Integer> usedToBeBrokerNodes() {
         return idAssignment.usedToBeBroker();
+    }
+
+    /**
+     * @return  The service account name for the pods in this pool, or null if the default Kafka service account should be used.
+     */
+    public String getServiceAccountName() {
+        return serviceAccountName;
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterTest.java
@@ -270,6 +270,91 @@ public class KafkaClusterTest {
     //////////
 
     @ParallelTest
+    public void testKafkaServiceAccountNameDefaultsToKafkaComponentName() {
+        List<StrimziPodSet> podSets = KC.generatePodSets(true, null, null, node -> Map.of());
+
+        podSets.forEach(podSet -> PodSetUtils.podSetToPods(podSet).forEach(pod ->
+                assertThat(pod.getSpec().getServiceAccountName(), is(KafkaResources.kafkaComponentName(CLUSTER)))));
+    }
+
+    @ParallelTest
+    public void testKafkaServiceAccountNameCanBeConfiguredOnKafkaCluster() {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withServiceAccountName("kafkabroker")
+                    .endKafka()
+                .endSpec()
+                .build();
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(POOL_CONTROLLERS, POOL_MIXED, POOL_BROKERS), Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, KafkaMetadataConfigurationState.KRAFT, null, SHARED_ENV_PROVIDER);
+
+        List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, node -> Map.of());
+
+        podSets.forEach(podSet -> PodSetUtils.podSetToPods(podSet).forEach(pod ->
+                assertThat(pod.getSpec().getServiceAccountName(), is("kafkabroker"))));
+    }
+
+    @ParallelTest
+    public void testKafkaServiceAccountNameCanBeOverriddenOnKafkaNodePool() {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withServiceAccountName("kafkabroker")
+                    .endKafka()
+                .endSpec()
+                .build();
+        KafkaNodePool brokers = new KafkaNodePoolBuilder(POOL_BROKERS)
+                .editSpec()
+                    .withServiceAccountName("kafkabrokerb")
+                .endSpec()
+                .build();
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(POOL_CONTROLLERS, POOL_MIXED, brokers), Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, KafkaMetadataConfigurationState.KRAFT, null, SHARED_ENV_PROVIDER);
+
+        List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, node -> Map.of());
+
+        podSets.forEach(podSet -> PodSetUtils.podSetToPods(podSet).forEach(pod -> {
+            if (pod.getMetadata().getName().startsWith(CLUSTER + "-brokers-")) {
+                assertThat(pod.getSpec().getServiceAccountName(), is("kafkabrokerb"));
+            } else {
+                assertThat(pod.getSpec().getServiceAccountName(), is("kafkabroker"));
+            }
+        }));
+    }
+
+    @ParallelTest
+    public void testClusterRoleBindingUsesEffectiveKafkaServiceAccountNames() {
+        String testNamespace = "other-namespace";
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editMetadata()
+                    .withNamespace(testNamespace)
+                .endMetadata()
+                .editSpec()
+                    .editKafka()
+                        .withServiceAccountName("kafkabroker")
+                        .withNewRack("my-topology-label")
+                    .endKafka()
+                .endSpec()
+                .build();
+        KafkaNodePool brokers = new KafkaNodePoolBuilder(POOL_BROKERS)
+                .editMetadata()
+                    .withNamespace(testNamespace)
+                .endMetadata()
+                .editSpec()
+                    .withServiceAccountName("kafkabrokerb")
+                .endSpec()
+                .build();
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, List.of(POOL_CONTROLLERS, POOL_MIXED, brokers), Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, true, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_KRAFT_VERSION_CHANGE, KafkaMetadataConfigurationState.KRAFT, null, SHARED_ENV_PROVIDER);
+
+        ClusterRoleBinding crb = kc.generateClusterRoleBinding(testNamespace);
+
+        assertThat(crb.getSubjects().stream().map(subject -> subject.getName()).collect(Collectors.toList()), containsInAnyOrder("kafkabroker", "kafkabrokerb"));
+        crb.getSubjects().forEach(subject -> assertThat(subject.getNamespace(), is(testNamespace)));
+    }
+
+    @ParallelTest
     public void testMetricsConfigMap() {
         ConfigMap metricsCm = io.strimzi.operator.cluster.TestUtils.getJmxMetricsCm("{\"animal\":\"wombat\"}", "kafka-metrics-config", "kafka-metrics-config.yml");
         Kafka kafkaAssembly = new KafkaBuilder(KAFKA)

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterZooBasedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterZooBasedTest.java
@@ -240,6 +240,24 @@ public class KafkaClusterZooBasedTest {
     //////////
 
     @ParallelTest
+    public void testKafkaServiceAccountNameCanBeConfiguredOnZooBasedKafkaCluster() {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withServiceAccountName("kafkabroker")
+                    .endKafka()
+                .endSpec()
+                .build();
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, KafkaMetadataConfigurationState.ZK, null, SHARED_ENV_PROVIDER);
+
+        List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, node -> Map.of());
+
+        podSets.forEach(podSet -> PodSetUtils.podSetToPods(podSet).forEach(pod ->
+                assertThat(pod.getSpec().getServiceAccountName(), is("kafkabroker"))));
+    }
+
+    @ParallelTest
     public void testMetricsConfigMap() {
         ConfigMap metricsCm = io.strimzi.operator.cluster.TestUtils.getJmxMetricsCm("{\"animal\":\"wombat\"}", "kafka-metrics-config", "kafka-metrics-config.yml");
 
@@ -3901,7 +3919,7 @@ public class KafkaClusterZooBasedTest {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .editKafka()
-                        .withVersion("3.9.0")
+                        .withVersion("3.9.1")
                         .withConfig(config)
                     .endKafka()
                 .endSpec()
@@ -3930,7 +3948,7 @@ public class KafkaClusterZooBasedTest {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .editKafka()
-                        .withVersion("3.9.0")
+                        .withVersion("3.9.1")
                         .withMetadataVersion("3.6-IV2")
                         .withConfig(Map.of())
                     .endKafka()
@@ -3963,7 +3981,7 @@ public class KafkaClusterZooBasedTest {
         Kafka kafka = new KafkaBuilder(KAFKA)
                 .editSpec()
                     .editKafka()
-                        .withVersion("3.9.0")
+                        .withVersion("3.9.1")
                         .withMetadataVersion("3.9-IV0")
                         .withConfig(config)
                 .endKafka()

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -100,6 +100,9 @@ include::../api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc[leveloffs
 |brokerRackInitImage
 |string
 |The image of the init container used for initializing the `broker.rack`.
+|serviceAccountName
+|string
+|The name of the service account used by the Kafka pods. If not set, the default Kafka service account for the cluster will be used.
 |livenessProbe
 |xref:type-Probe-{context}[`Probe`]
 |Pod liveness checking.
@@ -4592,6 +4595,9 @@ Used in: xref:type-KafkaNodePool-{context}[`KafkaNodePool`]
 |jvmOptions
 |xref:type-JvmOptions-{context}[`JvmOptions`]
 |JVM Options for pods.
+|serviceAccountName
+|string
+|The name of the service account used by the pods in this pool. If not set, the Kafka cluster service account is used.
 |template
 |xref:type-KafkaNodePoolTemplate-{context}[`KafkaNodePoolTemplate`]
 |Template for pool resources. The template allows users to specify how the resources belonging to this pool are generated.

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -791,6 +791,9 @@ spec:
                   brokerRackInitImage:
                     type: string
                     description: The image of the init container used for initializing the `broker.rack`.
+                  serviceAccountName:
+                    type: string
+                    description: "The name of the service account used by the Kafka pods. If not set, the default Kafka service account for the cluster will be used."
                   livenessProbe:
                     type: object
                     properties:

--- a/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
+++ b/packaging/install/cluster-operator/04A-Crd-kafkanodepool.yaml
@@ -235,6 +235,9 @@ spec:
                           description: The system property value.
                     description: A map of additional system properties which will be passed using the `-D` option to the JVM.
                 description: JVM Options for pods.
+              serviceAccountName:
+                type: string
+                description: "The name of the service account used by the pods in this pool. If not set, the Kafka cluster service account is used."
               template:
                 type: object
                 properties:


### PR DESCRIPTION
## Summary

Implements RIVERS-7928.

This adds broker-level ServiceAccount override support so Kafka broker pods can use an externally prepared Kubernetes ServiceAccount, for example `kafkabroker`, while preserving the default Strimzi behavior when unset.

New API fields:

- `Kafka.spec.kafka.serviceAccountName`
- `KafkaNodePool.spec.serviceAccountName`

Precedence:

1. `KafkaNodePool.spec.serviceAccountName`
2. `Kafka.spec.kafka.serviceAccountName`
3. default `<cluster>-kafka`

## Details

- Stores the effective broker ServiceAccount on each `KafkaPool`.
- Uses the effective ServiceAccount when generating Kafka broker `StrimziPodSet` pod specs.
- Updates broker `ClusterRoleBinding` generation to include all unique effective ServiceAccounts used by Kafka pools.
- Keeps default `<cluster>-kafka` ServiceAccount reconciliation unchanged.
- Does not create or manage custom ServiceAccounts. They must exist before use.
- Regenerates CRDs and generated API documentation.

## Criteo Context

This allows Criteo k8s-init / LDAP integration to map broker pods to a stable account such as `svc-kafkabroker`, instead of relying on Strimzi-generated names like `svc-kafka-exp-kafka`, which do not fit our LDAP naming constraints.

## Testing

```shell
mvn -pl api -am process-classes -DskipTests
mvn -pl cluster-operator -am test -Dtest=KafkaClusterTest#testKafkaServiceAccountNameDefaultsToKafkaComponentName+testKafkaServiceAccountNameCanBeConfiguredOnKafkaCluster+testKafkaServiceAccountNameCanBeOverriddenOnKafkaNodePool+testClusterRoleBindingUsesEffectiveKafkaServiceAccountNames,KafkaClusterZooBasedTest#testKafkaServiceAccountNameCanBeConfiguredOnZooBasedKafkaCluster -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
mvn -pl cluster-operator -am test -Dtest=KafkaClusterTest,KafkaClusterZooBasedTest,VirtualNodePoolConverterTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
git diff --check

