### PR TITLE
Add external ZooKeeper support for Kafka brokers

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/ExternalZooKeeperAuthenticationDigest.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/ExternalZooKeeperAuthenticationDigest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.kafka;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.api.kafka.model.common.GenericSecretSource;
+import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configures ZooKeeper Digest authentication for an external ZooKeeper ensemble.
+ */
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"type", "username", "jaasConfig"})
+@EqualsAndHashCode
+@ToString
+public class ExternalZooKeeperAuthenticationDigest implements UnknownPropertyPreserving {
+    public static final String TYPE_DIGEST = "digest";
+
+    private String username;
+    private GenericSecretSource jaasConfig;
+    private Map<String, Object> additionalProperties;
+
+    @Description("Must be `" + TYPE_DIGEST + "`.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getType() {
+        return TYPE_DIGEST;
+    }
+
+    @Description("Username used for ZooKeeper Digest authentication.")
+    @JsonProperty(required = true)
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    @Description("Reference to the `Secret` key containing the ZooKeeper client JAAS configuration file.")
+    @JsonProperty(required = true)
+    public GenericSecretSource getJaasConfig() {
+        return jaasConfig;
+    }
+
+    public void setJaasConfig(GenericSecretSource jaasConfig) {
+        this.jaasConfig = jaasConfig;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : Map.of();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>(2);
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/ExternalZooKeeperSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/ExternalZooKeeperSpec.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.kafka;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.common.Constants;
+import io.strimzi.api.kafka.model.common.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configures Kafka brokers to use an external ZooKeeper ensemble.
+ */
+@Buildable(
+        editableEnabled = false,
+        builderPackage = Constants.FABRIC8_KUBERNETES_API
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"connect", "tls", "authentication", "config"})
+@EqualsAndHashCode
+@ToString
+public class ExternalZooKeeperSpec implements UnknownPropertyPreserving {
+    private String connect;
+    private Boolean tls;
+    private ExternalZooKeeperAuthenticationDigest authentication;
+    private Map<String, Object> config = new HashMap<>(0);
+    private Map<String, Object> additionalProperties;
+
+    @Description("Connection string for the external ZooKeeper ensemble, including the ZooKeeper chroot.")
+    @JsonProperty(required = true)
+    public String getConnect() {
+        return connect;
+    }
+
+    public void setConnect(String connect) {
+        this.connect = connect;
+    }
+
+    @Description("Whether TLS encryption should be used when connecting to ZooKeeper. TLS for external ZooKeeper is not supported yet.")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public Boolean getTls() {
+        return tls;
+    }
+
+    public void setTls(Boolean tls) {
+        this.tls = tls;
+    }
+
+    @Description("Digest authentication configuration for connecting to the external ZooKeeper ensemble.")
+    @JsonProperty(required = true)
+    public ExternalZooKeeperAuthenticationDigest getAuthentication() {
+        return authentication;
+    }
+
+    public void setAuthentication(ExternalZooKeeperAuthenticationDigest authentication) {
+        this.authentication = authentication;
+    }
+
+    @Description("Additional ZooKeeper client configuration properties.")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, Object> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, Object> config) {
+        this.config = config;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties != null ? this.additionalProperties : Map.of();
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        if (this.additionalProperties == null) {
+            this.additionalProperties = new HashMap<>(2);
+        }
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java
@@ -48,7 +48,7 @@ import java.util.Map;
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "version", "metadataVersion", "replicas", "image", "listeners", "config", "storage", "authorization", "rack",
+    "version", "metadataVersion", "replicas", "image", "listeners", "config", "externalZooKeeper", "storage", "authorization", "rack",
     "brokerRackInitImage", "serviceAccountName", "livenessProbe", "readinessProbe", "jvmOptions", "jmxOptions", "resources", "metricsConfig",
     "logging", "template", "tieredStorage", "quotas"})
 @EqualsAndHashCode
@@ -73,6 +73,7 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
     private String version;
     private String metadataVersion;
     private Map<String, Object> config = new HashMap<>(0);
+    private ExternalZooKeeperSpec externalZooKeeper;
     private String brokerRackInitImage;
     private Rack rack;
     private Logging logging;
@@ -122,6 +123,16 @@ public class KafkaClusterSpec implements HasConfigurableMetrics, HasConfigurable
 
     public void setConfig(Map<String, Object> config) {
         this.config = config;
+    }
+
+    @Description("Configuration for connecting Kafka brokers to an external ZooKeeper ensemble instead of deploying a Strimzi-managed ZooKeeper cluster.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public ExternalZooKeeperSpec getExternalZooKeeper() {
+        return externalZooKeeper;
+    }
+
+    public void setExternalZooKeeper(ExternalZooKeeperSpec externalZooKeeper) {
+        this.externalZooKeeper = externalZooKeeper;
     }
 
     @Description("The image of the init container used for initializing the `broker.rack`.")

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/EntityOperator.java
@@ -28,6 +28,7 @@ import io.strimzi.operator.cluster.ClusterOperatorConfig;
 import io.strimzi.operator.cluster.model.securityprofiles.PodSecurityProviderContextImpl;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.Util;
+import io.strimzi.operator.common.model.InvalidResourceException;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -119,6 +120,10 @@ public class EntityOperator extends AbstractModel {
 
         if (entityOperatorSpec != null
                 && (entityOperatorSpec.getUserOperator() != null || entityOperatorSpec.getTopicOperator() != null)) {
+            if (kafkaAssembly.getSpec().getKafka().getExternalZooKeeper() != null) {
+                throw new InvalidResourceException("spec.entityOperator is not supported with spec.kafka.externalZooKeeper.");
+            }
+
             EntityOperator result = new EntityOperator(reconciliation, kafkaAssembly, sharedEnvironmentProvider);
 
             EntityTopicOperator topicOperator = EntityTopicOperator.fromCrd(reconciliation, kafkaAssembly, sharedEnvironmentProvider, config);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilder.java
@@ -7,6 +7,7 @@ package io.strimzi.operator.cluster.model;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.strimzi.api.kafka.model.common.CertAndKeySecretSource;
 import io.strimzi.api.kafka.model.common.Rack;
+import io.strimzi.api.kafka.model.kafka.ExternalZooKeeperSpec;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorization;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationCustom;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationKeycloak;
@@ -44,6 +45,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -181,6 +183,24 @@ public class KafkaBrokerConfigurationBuilder {
         writer.println("zookeeper.ssl.truststore.location=/tmp/kafka/cluster.truststore.p12");
         writer.println("zookeeper.ssl.truststore.password=" + PLACEHOLDER_CERT_STORE_PASSWORD);
         writer.println("zookeeper.ssl.truststore.type=PKCS12");
+        writer.println();
+
+        return this;
+    }
+
+    /**
+     * Configures the connection URL and client properties for an external ZooKeeper ensemble.
+     *
+     * @param externalZooKeeper External ZooKeeper configuration from the Kafka custom resource
+     *
+     * @return Returns the builder instance
+     */
+    public KafkaBrokerConfigurationBuilder withExternalZooKeeper(ExternalZooKeeperSpec externalZooKeeper)  {
+        printSectionHeader("Zookeeper");
+        writer.println(String.format("zookeeper.connect=%s", externalZooKeeper.getConnect()));
+        if (externalZooKeeper.getConfig() != null) {
+            new TreeMap<>(externalZooKeeper.getConfig()).forEach((key, value) -> writer.println(key + "=" + value));
+        }
         writer.println();
 
         return this;

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KafkaCluster.java
@@ -40,6 +40,7 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import io.strimzi.api.kafka.model.common.CertAndKeySecretSource;
 import io.strimzi.api.kafka.model.common.Condition;
+import io.strimzi.api.kafka.model.common.GenericSecretSource;
 import io.strimzi.api.kafka.model.common.Rack;
 import io.strimzi.api.kafka.model.common.template.ContainerTemplate;
 import io.strimzi.api.kafka.model.common.template.ExternalTrafficPolicy;
@@ -47,6 +48,8 @@ import io.strimzi.api.kafka.model.common.template.InternalServiceTemplate;
 import io.strimzi.api.kafka.model.common.template.PodDisruptionBudgetTemplate;
 import io.strimzi.api.kafka.model.common.template.PodTemplate;
 import io.strimzi.api.kafka.model.common.template.ResourceTemplate;
+import io.strimzi.api.kafka.model.kafka.ExternalZooKeeperAuthenticationDigest;
+import io.strimzi.api.kafka.model.kafka.ExternalZooKeeperSpec;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorization;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationKeycloak;
@@ -146,6 +149,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     protected static final String CLIENT_CA_CERTS_VOLUME_MOUNT = "/opt/kafka/client-ca-certs";
     protected static final String TRUSTED_CERTS_BASE_VOLUME_MOUNT = "/opt/kafka/certificates";
     protected static final String CUSTOM_AUTHN_SECRETS_VOLUME_MOUNT = "/opt/kafka/custom-authn-secrets";
+    protected static final String EXTERNAL_ZOOKEEPER_AUTH_VOLUME = "external-zookeeper-auth";
+    private static final String EXTERNAL_ZOOKEEPER_AUTH_VOLUME_MOUNT = "/opt/kafka/external-zookeeper-auth";
     private static final String LOG_AND_METRICS_CONFIG_VOLUME_NAME = "kafka-metrics-and-logging";
     private static final String LOG_AND_METRICS_CONFIG_VOLUME_MOUNT = "/opt/kafka/custom-config/";
 
@@ -210,8 +215,14 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
      * Key under which the class of the quota plugin can be configured
      */
     private static final String CLIENT_CALLBACK_CLASS_OPTION = "client.quota.callback.class";
+    private static final Set<String> ALLOWED_EXTERNAL_ZOOKEEPER_CONFIG_OPTIONS = Set.of(
+            "zookeeper.connection.timeout.ms",
+            "zookeeper.session.timeout.ms",
+            "zookeeper.set.acl"
+    );
 
     // Kafka configuration
+    private ExternalZooKeeperSpec externalZooKeeper;
     private Rack rack;
     private String initImage;
     private List<GenericKafkaListener> listeners;
@@ -318,10 +329,12 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         validateIntConfigProperty("offsets.topic.replication.factor", kafkaClusterSpec, numberOfBrokers);
         validateIntConfigProperty("transaction.state.log.replication.factor", kafkaClusterSpec, numberOfBrokers);
         validateIntConfigProperty("transaction.state.log.min.isr", kafkaClusterSpec, numberOfBrokers);
+        validateExternalZooKeeper(kafkaSpec, kafkaClusterSpec);
 
         result.image = versions.kafkaImage(kafkaClusterSpec.getImage(), kafkaClusterSpec.getVersion());
         result.readinessProbeOptions = ProbeUtils.extractReadinessProbeOptionsOrDefault(kafkaClusterSpec, ProbeUtils.DEFAULT_HEALTHCHECK_OPTIONS);
         result.livenessProbeOptions = ProbeUtils.extractLivenessProbeOptionsOrDefault(kafkaClusterSpec, ProbeUtils.DEFAULT_HEALTHCHECK_OPTIONS);
+        result.externalZooKeeper = kafkaClusterSpec.getExternalZooKeeper();
         result.rack = kafkaClusterSpec.getRack();
 
         String initImage = kafkaClusterSpec.getBrokerRackInitImage();
@@ -619,6 +632,74 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                 throw new InvalidResourceException("Property " + propertyName + " should be an integer");
             }
         }
+    }
+
+    private static void validateExternalZooKeeper(KafkaSpec kafkaSpec, KafkaClusterSpec kafkaClusterSpec) {
+        ExternalZooKeeperSpec externalZooKeeper = kafkaClusterSpec.getExternalZooKeeper();
+
+        if (externalZooKeeper == null) {
+            return;
+        }
+
+        validateExternalZooKeeperMode(kafkaSpec);
+        validateExternalZooKeeperConnect(externalZooKeeper);
+        validateExternalZooKeeperAuthentication(externalZooKeeper.getAuthentication());
+        validateExternalZooKeeperConfig(externalZooKeeper);
+    }
+
+    private static void validateExternalZooKeeperMode(KafkaSpec kafkaSpec) {
+        if (kafkaSpec.getZookeeper() != null) {
+            throw new InvalidResourceException("spec.zookeeper and spec.kafka.externalZooKeeper cannot be used together.");
+        }
+
+        if (kafkaSpec.getEntityOperator() != null) {
+            throw new InvalidResourceException("spec.entityOperator is not supported with spec.kafka.externalZooKeeper.");
+        }
+    }
+
+    private static void validateExternalZooKeeperConnect(ExternalZooKeeperSpec externalZooKeeper) {
+        if (externalZooKeeper.getConnect() == null || externalZooKeeper.getConnect().isBlank()) {
+            throw new InvalidResourceException("spec.kafka.externalZooKeeper.connect must be set.");
+        }
+
+        if (!hasZooKeeperChroot(externalZooKeeper.getConnect())) {
+            throw new InvalidResourceException("spec.kafka.externalZooKeeper.connect must include a ZooKeeper chroot.");
+        }
+
+        if (Boolean.TRUE.equals(externalZooKeeper.getTls())) {
+            throw new InvalidResourceException("spec.kafka.externalZooKeeper.tls is not supported yet.");
+        }
+    }
+
+    private static void validateExternalZooKeeperAuthentication(ExternalZooKeeperAuthenticationDigest authentication) {
+        if (authentication == null) {
+            throw new InvalidResourceException("spec.kafka.externalZooKeeper.authentication must be configured.");
+        }
+
+        if (authentication.getUsername() == null || authentication.getUsername().isBlank()) {
+            throw new InvalidResourceException("spec.kafka.externalZooKeeper.authentication.username must be set.");
+        }
+
+        GenericSecretSource jaasConfig = authentication.getJaasConfig();
+        if (jaasConfig == null || jaasConfig.getSecretName() == null || jaasConfig.getSecretName().isBlank()
+                || jaasConfig.getKey() == null || jaasConfig.getKey().isBlank()) {
+            throw new InvalidResourceException("spec.kafka.externalZooKeeper.authentication.jaasConfig must reference a Secret name and key.");
+        }
+    }
+
+    private static void validateExternalZooKeeperConfig(ExternalZooKeeperSpec externalZooKeeper) {
+        if (externalZooKeeper.getConfig() != null) {
+            for (String option : externalZooKeeper.getConfig().keySet()) {
+                if (!ALLOWED_EXTERNAL_ZOOKEEPER_CONFIG_OPTIONS.contains(option)) {
+                    throw new InvalidResourceException("Unsupported spec.kafka.externalZooKeeper.config option: " + option);
+                }
+            }
+        }
+    }
+
+    private static boolean hasZooKeeperChroot(String connect) {
+        int chrootStart = connect.indexOf('/');
+        return chrootStart > 0 && chrootStart < connect.length() - 1;
     }
 
     /**
@@ -1354,6 +1435,15 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
                 volumeList.add(VolumeUtils.createEmptyDirVolume(INIT_VOLUME_NAME, "1Mi", "Memory"));
             }
 
+            if (isExternalZooKeeperDigestAuthenticationEnabled()) {
+                GenericSecretSource jaasConfig = externalZooKeeperJaasConfig();
+                volumeList.add(VolumeUtils.createSecretVolume(
+                        EXTERNAL_ZOOKEEPER_AUTH_VOLUME,
+                        jaasConfig.getSecretName(),
+                        Map.of(jaasConfig.getKey(), jaasConfig.getKey()),
+                        isOpenShift));
+            }
+
             // Listener specific volumes related to their specific authentication or encryption settings
             for (GenericKafkaListener listener : listeners) {
                 if (listener.isTls()
@@ -1443,6 +1533,10 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
             // Volume for sharing data with init container for rack awareness and node port listeners
             if (rack != null || isExposedWithNodePort()) {
                 volumeMountList.add(VolumeUtils.createVolumeMount(INIT_VOLUME_NAME, INIT_VOLUME_MOUNT));
+            }
+
+            if (isExternalZooKeeperDigestAuthenticationEnabled()) {
+                volumeMountList.add(VolumeUtils.createVolumeMount(EXTERNAL_ZOOKEEPER_AUTH_VOLUME, EXTERNAL_ZOOKEEPER_AUTH_VOLUME_MOUNT));
             }
 
             // Listener specific volumes related to their specific authentication or encryption settings
@@ -1603,6 +1697,8 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
 
         // Some environment variables are used only on nodes with broker role and are not needed on controller-only nodes
         if (pool.isBroker()) {
+            addExternalZooKeeperDigestJaasEnvVar(varList);
+
             for (GenericKafkaListener listener : listeners) {
                 if (ListenersUtils.isListenerWithOAuth(listener)) {
                     KafkaListenerAuthenticationOAuth oauth = (KafkaListenerAuthenticationOAuth) listener.getAuth();
@@ -1639,6 +1735,36 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
         ContainerUtils.addContainerEnvsToExistingEnvs(reconciliation, varList, pool.templateContainer);
 
         return varList;
+    }
+
+    private boolean isExternalZooKeeperDigestAuthenticationEnabled() {
+        return externalZooKeeper != null
+                && externalZooKeeper.getAuthentication() != null
+                && externalZooKeeper.getAuthentication().getJaasConfig() != null;
+    }
+
+    private GenericSecretSource externalZooKeeperJaasConfig() {
+        return externalZooKeeper.getAuthentication().getJaasConfig();
+    }
+
+    private void addExternalZooKeeperDigestJaasEnvVar(List<EnvVar> varList) {
+        if (!isExternalZooKeeperDigestAuthenticationEnabled()) {
+            return;
+        }
+
+        String jaasPath = EXTERNAL_ZOOKEEPER_AUTH_VOLUME_MOUNT + "/" + externalZooKeeperJaasConfig().getKey();
+        String jaasProperty = "-Djava.security.auth.login.config=" + jaasPath;
+        EnvVar existingJavaSystemProperties = varList.stream()
+                .filter(env -> ENV_VAR_STRIMZI_JAVA_SYSTEM_PROPERTIES.equals(env.getName()))
+                .findFirst()
+                .orElse(null);
+
+        if (existingJavaSystemProperties != null) {
+            String existingValue = existingJavaSystemProperties.getValue();
+            existingJavaSystemProperties.setValue(existingValue == null || existingValue.isBlank() ? jaasProperty : existingValue + " " + jaasProperty);
+        } else {
+            varList.add(ContainerUtils.createEnvVar(ENV_VAR_STRIMZI_JAVA_SYSTEM_PROPERTIES, jaasProperty));
+        }
     }
 
     /**
@@ -1852,8 +1978,13 @@ public class KafkaCluster extends AbstractModel implements SupportsMetrics, Supp
     private void withZooKeeperOrKRaftConfiguration(KafkaPool pool, NodeRef node, KafkaBrokerConfigurationBuilder builder) {
         if ((node.broker() && this.kafkaMetadataConfigState.isZooKeeperToMigration()) ||
                 (node.controller() && this.kafkaMetadataConfigState.isPreMigrationToKRaft() && this.kafkaMetadataConfigState.isZooKeeperToPostMigration())) {
-            builder.withZookeeper(cluster);
-            LOGGER.debugCr(reconciliation, "Adding ZooKeeper connection configuration on node [{}]", node.podName());
+            if (externalZooKeeper != null) {
+                builder.withExternalZooKeeper(externalZooKeeper);
+                LOGGER.debugCr(reconciliation, "Adding external ZooKeeper connection configuration on node [{}]", node.podName());
+            } else {
+                builder.withZookeeper(cluster);
+                LOGGER.debugCr(reconciliation, "Adding ZooKeeper connection configuration on node [{}]", node.podName());
+            }
         }
 
         if ((node.broker() && this.kafkaMetadataConfigState.isMigration()) ||

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -604,6 +604,10 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
          * @return      Future with Reconciliation State
          */
         Future<ReconciliationState> reconcileZooKeeper(Clock clock)    {
+            if (kafkaAssembly.getSpec().getKafka().getExternalZooKeeper() != null) {
+                return Future.succeededFuture(this);
+            }
+
             return zooKeeperReconciler()
                     .compose(reconciler -> reconciler.reconcile(kafkaStatus, clock))
                     .map(this);

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaBrokerConfigurationBuilderTest.java
@@ -8,6 +8,7 @@ import io.strimzi.api.kafka.model.common.CertSecretSource;
 import io.strimzi.api.kafka.model.common.CertSecretSourceBuilder;
 import io.strimzi.api.kafka.model.common.Rack;
 import io.strimzi.api.kafka.model.kafka.EphemeralStorageBuilder;
+import io.strimzi.api.kafka.model.kafka.ExternalZooKeeperSpecBuilder;
 import io.strimzi.api.kafka.model.kafka.JbodStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorization;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationKeycloakBuilder;
@@ -64,6 +65,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 
 @ParallelSuite
+@SuppressWarnings({"checkstyle:ClassDataAbstractionCoupling"})
 public class KafkaBrokerConfigurationBuilderTest {
     private final static NodeRef NODE_REF = new NodeRef("my-cluster-kafka-2", 2, "kafka", false, true);
 
@@ -283,6 +285,28 @@ public class KafkaBrokerConfigurationBuilderTest {
                 "zookeeper.ssl.truststore.location=/tmp/kafka/cluster.truststore.p12",
                 "zookeeper.ssl.truststore.password=${strimzienv:CERTS_STORE_PASSWORD}",
                 "zookeeper.ssl.truststore.type=PKCS12"));
+    }
+
+    @ParallelTest
+    public void testExternalZookeeperConfig()  {
+        String configuration = new KafkaBrokerConfigurationBuilder(Reconciliation.DUMMY_RECONCILIATION, NODE_REF, KafkaMetadataConfigurationState.ZK)
+                .withExternalZooKeeper(new ExternalZooKeeperSpecBuilder()
+                        .withConnect("zk-0.example.com:2181,zk-1.example.com:2181,zk-2.example.com:2181/kafka")
+                        .withConfig(Map.of(
+                                "zookeeper.session.timeout.ms", "60000",
+                                "zookeeper.connection.timeout.ms", "1000000",
+                                "zookeeper.set.acl", "true"))
+                        .build())
+                .build();
+
+        assertThat(configuration, isEquivalent("broker.id=2",
+                "node.id=2",
+                "zookeeper.connect=zk-0.example.com:2181,zk-1.example.com:2181,zk-2.example.com:2181/kafka",
+                "zookeeper.connection.timeout.ms=1000000",
+                "zookeeper.session.timeout.ms=60000",
+                "zookeeper.set.acl=true"));
+        assertThat(configuration, not(containsString("zookeeper.ssl.")));
+        assertThat(configuration, not(containsString("zookeeper.clientCnxnSocket")));
     }
 
     @ParallelTest

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterZooBasedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KafkaClusterZooBasedTest.java
@@ -65,6 +65,8 @@ import io.strimzi.api.kafka.model.common.template.ExternalTrafficPolicy;
 import io.strimzi.api.kafka.model.common.template.IpFamily;
 import io.strimzi.api.kafka.model.common.template.IpFamilyPolicy;
 import io.strimzi.api.kafka.model.kafka.EphemeralStorageBuilder;
+import io.strimzi.api.kafka.model.kafka.ExternalZooKeeperSpec;
+import io.strimzi.api.kafka.model.kafka.ExternalZooKeeperSpecBuilder;
 import io.strimzi.api.kafka.model.kafka.JbodStorageBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaAuthorizationKeycloakBuilder;
@@ -226,6 +228,39 @@ public class KafkaClusterZooBasedTest {
         assertThat(headless.getMetadata().getLabels().containsKey(Labels.STRIMZI_DISCOVERY_LABEL), is(false));
     }
 
+    private ExternalZooKeeperSpec externalZooKeeper() {
+        return new ExternalZooKeeperSpecBuilder()
+                .withConnect("zk-0.example.com:2181,zk-1.example.com:2181,zk-2.example.com:2181/kafka")
+                .withNewAuthentication()
+                    .withUsername("kafka")
+                    .withJaasConfig(new GenericSecretSourceBuilder()
+                            .withSecretName("external-zookeeper-secret")
+                            .withKey("zookeeper-jaas.conf")
+                            .build())
+                .endAuthentication()
+                .withConfig(Map.of(
+                        "zookeeper.session.timeout.ms", "60000",
+                        "zookeeper.connection.timeout.ms", "1000000",
+                        "zookeeper.set.acl", "true"))
+                .build();
+    }
+
+    private Kafka externalZooKeeperKafka() {
+        return externalZooKeeperKafka(externalZooKeeper());
+    }
+
+    private Kafka externalZooKeeperKafka(ExternalZooKeeperSpec externalZooKeeper) {
+        return new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .withZookeeper(null)
+                    .withEntityOperator(null)
+                    .editKafka()
+                        .withExternalZooKeeper(externalZooKeeper)
+                    .endKafka()
+                .endSpec()
+                .build();
+    }
+
     private Secret generateBrokerSecret(Set<String> externalBootstrapAddress, Map<Integer, Set<String>> externalAddresses) {
         ClusterCa clusterCa = new ClusterCa(Reconciliation.DUMMY_RECONCILIATION, new OpenSslCertManager(), new PasswordGenerator(10, "a", "a"), CLUSTER, null, null);
         clusterCa.createRenewOrReplace(NAMESPACE, emptyMap(), emptyMap(), emptyMap(), null, true);
@@ -255,6 +290,136 @@ public class KafkaClusterZooBasedTest {
 
         podSets.forEach(podSet -> PodSetUtils.podSetToPods(podSet).forEach(pod ->
                 assertThat(pod.getSpec().getServiceAccountName(), is("kafkabroker"))));
+    }
+
+    @ParallelTest
+    public void testExternalZooKeeperPerBrokerConfiguration() {
+        Map<Integer, Map<String, String>> advertisedHostnames = Map.of(
+                0, Map.of("PLAIN_9092", "broker-0", "TLS_9093", "broker-0"),
+                1, Map.of("PLAIN_9092", "broker-1", "TLS_9093", "broker-1"),
+                2, Map.of("PLAIN_9092", "broker-2", "TLS_9093", "broker-2")
+        );
+        Map<Integer, Map<String, String>> advertisedPorts = Map.of(
+                0, Map.of("PLAIN_9092", "9092", "TLS_9093", "10000"),
+                1, Map.of("PLAIN_9092", "9092", "TLS_9093", "10001"),
+                2, Map.of("PLAIN_9092", "9092", "TLS_9093", "10002")
+        );
+        Kafka kafka = externalZooKeeperKafka();
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, KafkaMetadataConfigurationState.ZK, null, SHARED_ENV_PROVIDER);
+
+        String brokerConfig = kc.generatePerBrokerConfiguration(1, advertisedHostnames, advertisedPorts);
+
+        assertThat(brokerConfig, containsString("zookeeper.connect=zk-0.example.com:2181,zk-1.example.com:2181,zk-2.example.com:2181/kafka"));
+        assertThat(brokerConfig, containsString("zookeeper.connection.timeout.ms=1000000"));
+        assertThat(brokerConfig, containsString("zookeeper.session.timeout.ms=60000"));
+        assertThat(brokerConfig, containsString("zookeeper.set.acl=true"));
+        assertThat(brokerConfig, not(containsString("zookeeper.ssl.")));
+        assertThat(brokerConfig, not(containsString("zookeeper.clientCnxnSocket")));
+    }
+
+    @ParallelTest
+    public void testExternalZooKeeperDigestJaasSecretIsMountedInBrokerPods() {
+        Kafka kafka = externalZooKeeperKafka();
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, SHARED_ENV_PROVIDER);
+        KafkaCluster kc = KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, KafkaMetadataConfigurationState.ZK, null, SHARED_ENV_PROVIDER);
+
+        List<StrimziPodSet> podSets = kc.generatePodSets(true, null, null, node -> Map.of());
+        Pod pod = PodSetUtils.podSetToPods(podSets.get(0)).get(0);
+        Volume volume = pod.getSpec().getVolumes().stream()
+                .filter(vol -> KafkaCluster.EXTERNAL_ZOOKEEPER_AUTH_VOLUME.equals(vol.getName()))
+                .findFirst()
+                .orElseThrow();
+        Container kafkaContainer = pod.getSpec().getContainers().stream()
+                .filter(container -> "kafka".equals(container.getName()))
+                .findFirst()
+                .orElseThrow();
+        VolumeMount volumeMount = kafkaContainer.getVolumeMounts().stream()
+                .filter(mount -> KafkaCluster.EXTERNAL_ZOOKEEPER_AUTH_VOLUME.equals(mount.getName()))
+                .findFirst()
+                .orElseThrow();
+        EnvVar javaSystemProperties = kafkaContainer.getEnv().stream()
+                .filter(env -> "STRIMZI_JAVA_SYSTEM_PROPERTIES".equals(env.getName()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(volume.getSecret().getSecretName(), is("external-zookeeper-secret"));
+        assertThat(volume.getSecret().getItems().get(0).getKey(), is("zookeeper-jaas.conf"));
+        assertThat(volume.getSecret().getItems().get(0).getPath(), is("zookeeper-jaas.conf"));
+        assertThat(volumeMount.getMountPath(), is("/opt/kafka/external-zookeeper-auth"));
+        assertThat(javaSystemProperties.getValue(), containsString("-Djava.security.auth.login.config=/opt/kafka/external-zookeeper-auth/zookeeper-jaas.conf"));
+    }
+
+    @ParallelTest
+    public void testExternalZooKeeperCannotBeUsedWithManagedZooKeeper() {
+        Kafka kafka = new KafkaBuilder(KAFKA)
+                .editSpec()
+                    .editKafka()
+                        .withExternalZooKeeper(externalZooKeeper())
+                    .endKafka()
+                .endSpec()
+                .build();
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, SHARED_ENV_PROVIDER);
+
+        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, KafkaMetadataConfigurationState.ZK, null, SHARED_ENV_PROVIDER));
+
+        assertThat(ex.getMessage(), containsString("spec.zookeeper and spec.kafka.externalZooKeeper cannot be used together"));
+    }
+
+    @ParallelTest
+    public void testExternalZooKeeperRequiresChroot() {
+        ExternalZooKeeperSpec externalZooKeeper = new ExternalZooKeeperSpecBuilder(externalZooKeeper())
+                .withConnect("zk-0.example.com:2181,zk-1.example.com:2181,zk-2.example.com:2181")
+                .build();
+        Kafka kafka = externalZooKeeperKafka(externalZooKeeper);
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, SHARED_ENV_PROVIDER);
+
+        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, KafkaMetadataConfigurationState.ZK, null, SHARED_ENV_PROVIDER));
+
+        assertThat(ex.getMessage(), containsString("spec.kafka.externalZooKeeper.connect must include a ZooKeeper chroot"));
+    }
+
+    @ParallelTest
+    public void testExternalZooKeeperTlsRejectedUntilSupported() {
+        ExternalZooKeeperSpec externalZooKeeper = new ExternalZooKeeperSpecBuilder(externalZooKeeper())
+                .withTls(true)
+                .build();
+        Kafka kafka = externalZooKeeperKafka(externalZooKeeper);
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, SHARED_ENV_PROVIDER);
+
+        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, KafkaMetadataConfigurationState.ZK, null, SHARED_ENV_PROVIDER));
+
+        assertThat(ex.getMessage(), containsString("spec.kafka.externalZooKeeper.tls is not supported yet"));
+    }
+
+    @ParallelTest
+    public void testExternalZooKeeperRejectsUnknownClientConfig() {
+        ExternalZooKeeperSpec externalZooKeeper = new ExternalZooKeeperSpecBuilder(externalZooKeeper())
+                .withConfig(Map.of("zookeeper.unexpected.option", "true"))
+                .build();
+        Kafka kafka = externalZooKeeperKafka(externalZooKeeper);
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, SHARED_ENV_PROVIDER);
+
+        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, KafkaMetadataConfigurationState.ZK, null, SHARED_ENV_PROVIDER));
+
+        assertThat(ex.getMessage(), containsString("Unsupported spec.kafka.externalZooKeeper.config option: zookeeper.unexpected.option"));
+    }
+
+    @ParallelTest
+    public void testExternalZooKeeperRejectsEntityOperator() {
+        Kafka kafka = new KafkaBuilder(externalZooKeeperKafka())
+                .editSpec()
+                    .withNewEntityOperator()
+                        .withNewTopicOperator()
+                        .endTopicOperator()
+                    .endEntityOperator()
+                .endSpec()
+                .build();
+        List<KafkaPool> pools = NodePoolUtils.createKafkaPools(Reconciliation.DUMMY_RECONCILIATION, kafka, null, Map.of(), Map.of(), KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, false, SHARED_ENV_PROVIDER);
+
+        InvalidResourceException ex = assertThrows(InvalidResourceException.class, () -> KafkaCluster.fromCrd(Reconciliation.DUMMY_RECONCILIATION, kafka, pools, VERSIONS, KafkaVersionTestUtils.DEFAULT_ZOOKEEPER_VERSION_CHANGE, KafkaMetadataConfigurationState.ZK, null, SHARED_ENV_PROVIDER));
+
+        assertThat(ex.getMessage(), containsString("spec.entityOperator is not supported with spec.kafka.externalZooKeeper"));
     }
 
     @ParallelTest

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -88,6 +88,9 @@ include::../api/io.strimzi.api.kafka.model.kafka.KafkaClusterSpec.adoc[leveloffs
 |config
 |map
 |Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers, node.id, process.roles, controller., metadata.log.dir, zookeeper.metadata.migration.enable, client.quota.callback.static.kafka.admin., client.quota.callback.static.produce, client.quota.callback.static.fetch, client.quota.callback.static.storage.per.volume.limit.min.available., client.quota.callback.static.excluded.principal.name.list (with the exception of: zookeeper.connection.timeout.ms, sasl.server.max.receive.size, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation, cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms, cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms, cruise.control.metrics.topic.min.insync.replicas, controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms).
+|externalZooKeeper
+|xref:type-ExternalZooKeeperSpec-{context}[`ExternalZooKeeperSpec`]
+|Configuration for connecting Kafka brokers to an external ZooKeeper ensemble instead of deploying a Strimzi-managed ZooKeeper cluster.
 |storage
 |xref:type-EphemeralStorage-{context}[`EphemeralStorage`], xref:type-PersistentClaimStorage-{context}[`PersistentClaimStorage`], xref:type-JbodStorage-{context}[`JbodStorage`]
 |Storage configuration (disk). Cannot be updated. This property is required when node pools are not used.
@@ -350,7 +353,7 @@ It must have the value `oauth` for the type `KafkaListenerAuthenticationOAuth`.
 [id='type-GenericSecretSource-{context}']
 = `GenericSecretSource` schema reference
 
-Used in: xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`]
+Used in: xref:type-ExternalZooKeeperAuthenticationDigest-{context}[`ExternalZooKeeperAuthenticationDigest`], xref:type-KafkaClientAuthenticationOAuth-{context}[`KafkaClientAuthenticationOAuth`], xref:type-KafkaListenerAuthenticationCustom-{context}[`KafkaListenerAuthenticationCustom`], xref:type-KafkaListenerAuthenticationOAuth-{context}[`KafkaListenerAuthenticationOAuth`]
 
 
 [cols="2,2,3a",options="header"]
@@ -621,6 +624,49 @@ include::../api/io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerCo
 |externalIPs
 |string array
 |External IPs associated to the nodeport service. These IPs are used by clients external to the Kubernetes cluster to access the Kafka brokers. This field is helpful when `nodeport` without `externalIP` is not sufficient. For example on bare-metal Kubernetes clusters that do not support Loadbalancer service types. This field can only be used with `nodeport` type listener.
+|====
+
+[id='type-ExternalZooKeeperSpec-{context}']
+= `ExternalZooKeeperSpec` schema reference
+
+Used in: xref:type-KafkaClusterSpec-{context}[`KafkaClusterSpec`]
+
+
+[cols="2,2,3a",options="header"]
+|====
+|Property |Property type |Description
+|connect
+|string
+|Connection string for the external ZooKeeper ensemble, including the ZooKeeper chroot.
+|tls
+|boolean
+|Whether TLS encryption should be used when connecting to ZooKeeper. TLS for external ZooKeeper is not supported yet.
+|authentication
+|xref:type-ExternalZooKeeperAuthenticationDigest-{context}[`ExternalZooKeeperAuthenticationDigest`]
+|Digest authentication configuration for connecting to the external ZooKeeper ensemble.
+|config
+|map
+|Additional ZooKeeper client configuration properties.
+|====
+
+[id='type-ExternalZooKeeperAuthenticationDigest-{context}']
+= `ExternalZooKeeperAuthenticationDigest` schema reference
+
+Used in: xref:type-ExternalZooKeeperSpec-{context}[`ExternalZooKeeperSpec`]
+
+
+[cols="2,2,3a",options="header"]
+|====
+|Property |Property type |Description
+|type
+|string
+|Must be `digest`.
+|username
+|string
+|Username used for ZooKeeper Digest authentication.
+|jaasConfig
+|xref:type-GenericSecretSource-{context}[`GenericSecretSource`]
+|Reference to the `Secret` key containing the ZooKeeper client JAAS configuration file.
 |====
 
 [id='type-EphemeralStorage-{context}']

--- a/packaging/install/cluster-operator/040-Crd-kafka.yaml
+++ b/packaging/install/cluster-operator/040-Crd-kafka.yaml
@@ -557,6 +557,49 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                     type: object
                     description: "Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers, node.id, process.roles, controller., metadata.log.dir, zookeeper.metadata.migration.enable, client.quota.callback.static.kafka.admin., client.quota.callback.static.produce, client.quota.callback.static.fetch, client.quota.callback.static.storage.per.volume.limit.min.available., client.quota.callback.static.excluded.principal.name.list (with the exception of: zookeeper.connection.timeout.ms, sasl.server.max.receive.size, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation, cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms, cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms, cruise.control.metrics.topic.min.insync.replicas, controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms)."
+                  externalZooKeeper:
+                    type: object
+                    properties:
+                      connect:
+                        type: string
+                        description: "Connection string for the external ZooKeeper ensemble, including the ZooKeeper chroot."
+                      tls:
+                        type: boolean
+                        description: Whether TLS encryption should be used when connecting to ZooKeeper. TLS for external ZooKeeper is not supported yet.
+                      authentication:
+                        type: object
+                        properties:
+                          type:
+                            type: string
+                            description: Must be `digest`.
+                          username:
+                            type: string
+                            description: Username used for ZooKeeper Digest authentication.
+                          jaasConfig:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                                description: The key under which the secret value is stored in the Kubernetes Secret.
+                              secretName:
+                                type: string
+                                description: The name of the Kubernetes Secret containing the secret value.
+                            required:
+                            - key
+                            - secretName
+                            description: Reference to the `Secret` key containing the ZooKeeper client JAAS configuration file.
+                        required:
+                        - username
+                        - jaasConfig
+                        description: Digest authentication configuration for connecting to the external ZooKeeper ensemble.
+                      config:
+                        x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                        description: Additional ZooKeeper client configuration properties.
+                    required:
+                    - connect
+                    - authentication
+                    description: Configuration for connecting Kafka brokers to an external ZooKeeper ensemble instead of deploying a Strimzi-managed ZooKeeper cluster.
                   storage:
                     type: object
                     properties:


### PR DESCRIPTION
Add external ZooKeeper support for Kafka brokers

Add a Kafka externalZooKeeper API model, validation, broker config
generation, Digest JAAS Secret mounting, and reconciliation handling so
Kafka brokers can use an externally managed ZooKeeper ensemble instead
of a Strimzi-managed one.
