### PR TITLE
Fix external ZooKeeper reconciliation path

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/KRaftUtils.java
@@ -68,7 +68,7 @@ public class KRaftUtils {
         Set<String> errors = new HashSet<>(0);
 
         if (kafkaSpec != null)  {
-            if (kafkaSpec.getZookeeper() == null)   {
+            if (!usesExternalZooKeeper(kafkaSpec) && kafkaSpec.getZookeeper() == null)   {
                 errors.add("The .spec.zookeeper section of the Kafka custom resource is missing. " +
                         "This section is required for a ZooKeeper-based cluster.");
             }
@@ -91,6 +91,19 @@ public class KRaftUtils {
         if (!errors.isEmpty())  {
             throw new InvalidResourceException("Kafka configuration is not valid: " + errors);
         }
+    }
+
+    /**
+     * Checks whether the Kafka custom resource is configured to use an external ZooKeeper ensemble.
+     *
+     * @param kafkaSpec The .spec section of the Kafka CR which should be checked
+     *
+     * @return True when external ZooKeeper is configured. False otherwise.
+     */
+    public static boolean usesExternalZooKeeper(KafkaSpec kafkaSpec) {
+        return kafkaSpec != null
+                && kafkaSpec.getKafka() != null
+                && kafkaSpec.getKafka().getExternalZooKeeper() != null;
     }
 
     /**

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaAssemblyOperator.java
@@ -236,6 +236,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
 
         KafkaMetadataConfigurationState kafkaMetadataConfigState = reconcileState.kafkaMetadataStateManager.getMetadataConfigurationState();
         boolean nodePoolsEnabled = ReconcilerUtils.nodePoolsEnabled(reconcileState.kafkaAssembly);
+        boolean externalZooKeeperEnabled = KRaftUtils.usesExternalZooKeeper(reconcileState.kafkaAssembly.getSpec());
 
         // since PRE_MIGRATION phase (because it's when controllers are deployed during migration) we need to validate usage of node pools and features for KRaft
         if (kafkaMetadataConfigState.isPreMigrationToKRaft()) {
@@ -280,7 +281,7 @@ public class KafkaAssemblyOperator extends AbstractAssemblyOperator<KubernetesCl
                 .compose(state -> state.versionChange(kafkaMetadataConfigState.isKRaft()))
 
                 // Run reconciliations of the different components
-                .compose(state -> kafkaMetadataConfigState.isKRaft() ? Future.succeededFuture(state) : state.reconcileZooKeeper(clock))
+                .compose(state -> kafkaMetadataConfigState.isKRaft() || externalZooKeeperEnabled ? Future.succeededFuture(state) : state.reconcileZooKeeper(clock))
                 .compose(state -> reconcileState.kafkaMetadataStateManager.shouldDestroyZooKeeperNodes() ? state.reconcileZooKeeperEraser() : Future.succeededFuture(state))
                 .compose(state -> state.reconcileKafka(clock))
                 .compose(state -> state.reconcileEntityOperator(clock))

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsZooBasedTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/KRaftUtilsZooBasedTest.java
@@ -5,6 +5,8 @@
 package io.strimzi.operator.cluster.model;
 
 import io.strimzi.api.kafka.model.common.Condition;
+import io.strimzi.api.kafka.model.common.GenericSecretSourceBuilder;
+import io.strimzi.api.kafka.model.kafka.ExternalZooKeeperSpecBuilder;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.KafkaSpec;
@@ -100,6 +102,35 @@ public class KRaftUtilsZooBasedTest {
 
         InvalidResourceException e = assertThrows(InvalidResourceException.class, () -> KRaftUtils.validateKafkaCrForZooKeeper(spec, false));
         assertThat(e.getMessage(), containsString("The .spec.zookeeper section of the Kafka custom resource is missing. This section is required for a ZooKeeper-based cluster."));
+    }
+
+    @ParallelTest
+    public void testExternalZooKeeperClusterDoesNotRequireManagedZooSection() {
+        KafkaSpec spec = new KafkaSpecBuilder()
+                .withNewKafka()
+                    .withReplicas(3)
+                    .withListeners(new GenericKafkaListenerBuilder()
+                            .withName("listener")
+                            .withPort(9092)
+                            .withTls(true)
+                            .withType(KafkaListenerType.INTERNAL)
+                            .build())
+                    .withNewEphemeralStorage()
+                    .endEphemeralStorage()
+                    .withExternalZooKeeper(new ExternalZooKeeperSpecBuilder()
+                            .withConnect("zk-0.example.com:2181,zk-1.example.com:2181/kafka")
+                            .withNewAuthentication()
+                                .withUsername("kafka")
+                                .withJaasConfig(new GenericSecretSourceBuilder()
+                                        .withSecretName("external-zookeeper-secret")
+                                        .withKey("zookeeper-jaas.conf")
+                                        .build())
+                            .endAuthentication()
+                            .build())
+                .endKafka()
+                .build();
+
+        assertDoesNotThrow(() -> KRaftUtils.validateKafkaCrForZooKeeper(spec, false));
     }
 
     @ParallelTest


### PR DESCRIPTION
Follow-up to #9.

The operator still rejected the Kafka CR because `.spec.zookeeper` was absent, and the reconciliation path still attempted managed ZooKeeper handling.

This change:
- allows Kafka CR validation when `spec.kafka.externalZooKeeper` is configured without `spec.zookeeper`
- skips managed ZooKeeper reconciliation in external ZooKeeper mode
- adds a focused test for external ZooKeeper without managed ZooKeeper